### PR TITLE
Fix tcc_encoding: pin logical state with explicit logical Z

### DIFF
--- a/encoded/tcc.py
+++ b/encoded/tcc.py
@@ -107,11 +107,18 @@ def encode_steane() -> cirq.Circuit:
 
 
 def tcc_encoding(distance) -> cirq.Circuit:
-    # if distance == 3:
-    #     return encode_steane()
-    
+    n = (3 * distance ** 2 + 1) // 4
     generator_strs = get_stabilizer_generators(distance)[::-1]
-    return stimcirq.stim_circuit_to_cirq_circuit(stabilizers_to_encoder([stim.PauliString(s) for s in generator_strs]))
+    stabilizers = [stim.PauliString(s) for s in generator_strs]
+    # Pin the logical state by adding logical Z = Z on all n qubits. This
+    # commutes with every X stabilizer (each tile has even weight 4 or 6)
+    # and is not a product of Z stabilizers (n is odd for any odd distance),
+    # so it's a valid logical-Z representative. Without it, the tableau is
+    # underconstrained and stim chooses an arbitrary completion, which for
+    # d >= 5 lands in the logical-X eigenspace, preparing |+_L> instead of
+    # |0_L> and making |0_L> and |1_L> indistinguishable in the Z basis.
+    stabilizers.append(stim.PauliString("Z" * n))
+    return stimcirq.stim_circuit_to_cirq_circuit(stabilizers_to_encoder(stabilizers))
 
 
 def tcc_H(qreg: Sequence[cirq.Qid]) -> cirq.Circuit:


### PR DESCRIPTION
## Summary

`tcc_encoding` was producing the wrong state for d >= 5 because the tableau passed to `stim.Tableau.from_stabilizers(..., allow_underconstrained=True)` only contained the `n - 1` CSS stabilizer generators. That specifies the 2D codespace but leaves the state inside it unconstrained, and stim picks an arbitrary completion:

- d = 3: happened to land on a logical-Z eigenstate, so `X^n` flipped `0_L <-> 1_L` and things appeared to work.
- d >= 5: landed on a logical-X eigenstate (`|+_L>`), making `X^n` a stabilizer of the prepared state. Z-basis codewords for "0_L" and "1_L" became identical.

Fix: append `Z^n` (all-qubit Z) as an explicit logical-Z representative before building the tableau. It commutes with every X stabilizer (each color-code plaquette has even weight 4 or 6) and is not a product of Z stabilizers (n is odd for odd d), so it's a valid logical Z. Pinning its eigenvalue to +1 fully specifies `|0_L>`.

## Test plan

Verified for d in {3, 5, 7}:

- [x] Every provided stabilizer from `get_stabilizer_generators(d)` is a +1 eigenstate of the prepared state.
- [x] Applying `X^n` after encoding keeps all stabilizers at +1 but flips `<Z^n>` from +1 to -1 (i.e., prepares `|1_L>`).
- [x] Z-basis codeword sets for `|0_L>` and `|1_L>` are disjoint with sizes 8, 512, 2^18, matching the number of independent X stabilizers.
- [x] For d = 3, codewords don't match textbook Steane, but that's a qubit-relabeling difference from the triangular-color-code construction, not a correctness issue.