### PR TITLE
Fix tcc_test: pack full bitstring when extracting codewords

### DIFF
--- a/encoded/tcc_test.py
+++ b/encoded/tcc_test.py
@@ -31,8 +31,11 @@ print(encode_one)
 sampler_zero = stimcirq.cirq_circuit_to_stim_circuit(encode_zero + cirq.measure(qubits)).compile_sampler()
 sampler_one = stimcirq.cirq_circuit_to_stim_circuit(encode_one + cirq.measure(qubits)).compile_sampler()
 
-zero_states = sorted(set([int(b[0]) for b in sampler_zero.sample(nshots, bit_packed=True)]))
-one_states = sorted(set([int(b[0]) for b in sampler_one.sample(nshots, bit_packed=True)]))
+# bit_packed=True returns ceil(n/8) bytes per sample; int(b[0]) would only
+# read the first byte and silently truncate to qubits 0..7 (fine for d=3,
+# wrong for d>=5). int.from_bytes packs every byte so we cover all n qubits.
+zero_states = sorted({int.from_bytes(bytes(b), 'little') for b in sampler_zero.sample(nshots, bit_packed=True)})
+one_states = sorted({int.from_bytes(bytes(b), 'little') for b in sampler_one.sample(nshots, bit_packed=True)})
 
 # Display output.
 print("Sampled logical 0 states:")
@@ -41,6 +44,9 @@ print("\n" * 2)
 print("Sampled logical 1 states:")
 print(one_states)
 # These shouldn't be identical.
+assert set(zero_states).isdisjoint(set(one_states)), (
+    f"Logical 0 and logical 1 codeword sets overlap for distance {distance}."
+)
 """
 Logical 0 encoding:
                        ┌──┐           ┌──┐   ┌──┐   ┌──┐   ┌──┐               ┌──┐           ┌──┐       ┌──┐                   ┌──┐       ┌──┐           ┌──┐


### PR DESCRIPTION
## Summary

`sampler.sample(..., bit_packed=True)` returns `ceil(n/8)` bytes per row. `int(b[0])` only reads the **first byte**:

- d = 3 (n = 7): one byte is the full codeword, test passed.
- d ≥ 5: qubits 8 onward are dropped. The 8-qubit marginal of the triangular color code is X⊗n-invariant, so |0_L⟩ and |1_L⟩ printed identical.

Replaces the extraction with `int.from_bytes(bytes(b), 'little')` so every qubit is included, and adds an `assert` so future regressions fail loudly instead of silently printing two lists.

The same bug in the bell-state notebook has already been fixed on `main` (commit `8bf0660`, same one-liner on cells 26). This PR just completes the test.

## Test plan

- [x] Updated test passes for d ∈ {3, 5, 7} with disjoint codeword sets of size 8 / 512 / 2^18.
- [x] Meta-test: reverting to the buggy `int(b[0])` extraction causes the assert to fire at d=5 and d=7.